### PR TITLE
disable `fakeStop()` call

### DIFF
--- a/src/L.Routing.Edit.js
+++ b/src/L.Routing.Edit.js
@@ -521,7 +521,7 @@ L.Canvas.prototype._onTouch = function (e) {
     }
   }
   if (clickedLayer)  {
-    L.DomEvent.fakeStop(e);
+    // L.DomEvent.fakeStop(e);
     this._fireEvent([clickedLayer], e);
   }
 };


### PR DESCRIPTION
```
TypeError: L.DomEvent.fakeStop is not a function.
(In 'L.DomEvent.fakeStop(e)', 'L.DomEvent.fakeStop' is undefined)
```